### PR TITLE
 fixed undefined error on e.pipe in toMerge.forEach: fixed typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ es.merge = function (/*streams...*/) {
 
   if (toMerge.length) {
     toMerge.forEach(function (e) {
-      if(e. == undefined) return
+      if(e == undefined) return
       e.pipe(stream, {end: false})
       var ended = false
       e.on('end', function () {


### PR DESCRIPTION
Got an undefined error in our project. this is just a quick fix.
Here is an error:

TypeError: Cannot read property 'pipe' of undefined
  at /var/www/<project_name>/node_modules/event-stream/index.js:43:6
  at Array.forEach (native)